### PR TITLE
Fix typo in ebook banner

### DIFF
--- a/components/EbookBanner.tsx
+++ b/components/EbookBanner.tsx
@@ -8,7 +8,7 @@ export default function Banner() {
           <div className="max-w-2xl">
             <h2 className="text-2xl font-bold">Are you about to take the ARRT exam?</h2>
             <p className="mt-3 text-lg">
-              If you want the physical copy of the MRI ebook (MRI Fundamentals, MRI Proceduces and MRI Safety), you can download it here.
+              If you want the physical copy of the MRI ebook (MRI Fundamentals, MRI Procedures and MRI Safety), you can download it here.
             </p>
             <SignedIn>
               <button className="mt-6 bg-white text-black px-6 py-2 text-lg hover:bg-gray-300">


### PR DESCRIPTION
## Summary
- fix a small typo in the ebook banner text

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac1759be88321acc51156ceb2fb95