### PR TITLE
Fix incorrect header in topic page styles

### DIFF
--- a/app/learn-mri/topic/[slug]/page.module.css
+++ b/app/learn-mri/topic/[slug]/page.module.css
@@ -1,4 +1,4 @@
-/* app/section/[content_id]/page.module.css */
+/* Styles for topic pages */
 
 .container {
   max-width: 1200px;


### PR DESCRIPTION
## Summary
- correct header comment in `page.module.css` to describe topic page styles

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac404a2f08321b6f321314c8304b2