### PR TITLE
Improve mobile layout

### DIFF
--- a/app/learn-mri/page.tsx
+++ b/app/learn-mri/page.tsx
@@ -24,7 +24,7 @@ export default function LearnMRITextPage() {
               Begin by selecting one of the three parts below. Each part is organized into chapters, sections, subsections, 
               and topics, allowing you to dive deeply into the fascinating world of MRI.
             </p>
-            <div className="flex justify-between mt-10 pl-15 pr-15 w-full">
+            <div className="flex flex-col sm:flex-row justify-between mt-10 px-6 w-full gap-4">
               <Link 
                 href="/learn-mri/topic/mri-fundamentals" 
                 className="text-blue-600 hover:underline text-2xl"

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -95,7 +95,7 @@ export default async function NewsPage({ searchParams }: NewsPageProps) {
           });
           return (
             <div key={index} className={styles.tile}>
-              <div className="flex justify-between items-center">
+              <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
                 {/* Left side: Text content */}
                 <div className="flex flex-col gap-2">
                   <div className="flex items-center gap-2 mb-1">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
         </div>
 
         {/* Content sections */}
-        <div className="grid grid-cols-4 lg:grid-cols-1 gap-8">
+        <div className="mt-8">
           <NewsSection />
         </div>
 

--- a/app/podcasts/page.tsx
+++ b/app/podcasts/page.tsx
@@ -82,7 +82,7 @@ export default async function PodcastsPage({ searchParams }: PodcastsPageProps) 
               })
             : '';
           return (
-            <div key={index} className={`${styles.tile} flex items-center justify-between`}>
+            <div key={index} className={`${styles.tile} flex flex-col sm:flex-row items-center justify-between gap-4`}>
               <div className="flex flex-col gap-2">
                 <Link href={`/podcasts/${item.slug.current}`} className="group">
                   <h3 className="text-2xl font-bold mb-0 group-hover:text-blue-600 transition-colors">

--- a/components/EbookBanner.tsx
+++ b/components/EbookBanner.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 export default function Banner() {
     return (
-        <div className="w-full bg-black text-white p-8 mt-16 flex items-center justify-between">
+        <div className="w-full bg-black text-white p-8 mt-16 flex flex-col md:flex-row items-center justify-between gap-4">
           {/* Left side text content */}
           <div className="max-w-2xl">
             <h2 className="text-2xl font-bold">Are you about to take the ARRT exam?</h2>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 export default function Footer() {
   return (
     <footer className="w-full bg-gray-900 text-white py-6 mt-10">
-      <div className="container mx-auto flex justify-between items-center px-4">
+      <div className="container mx-auto flex flex-col md:flex-row justify-between items-center px-4 gap-4">
         <p>&copy; {new Date().getFullYear()} MRI simplified. All rights reserved.</p>
-        <nav>
+        <nav className="mt-2 md:mt-0">
           <ul className="flex space-x-4">
           <li>
               <Link href="/" className="hover:underline">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useState } from 'react';
 import {
   SignInButton,
   SignUpButton,
@@ -12,6 +13,7 @@ import {
 
 export default function Navbar() {
   const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const isActive = (path: string) => pathname === path || pathname.startsWith(`${path}/`);
 
@@ -23,7 +25,10 @@ export default function Navbar() {
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex justify-between items-center h-20">
           <div className="flex items-center">
-            <button className="md:hidden p-2 mr-2">
+            <button
+              className="md:hidden p-2 mr-2"
+              onClick={() => setMenuOpen(!menuOpen)}
+            >
               <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path
                   strokeLinecap="round"
@@ -52,6 +57,30 @@ export default function Navbar() {
               Podcasts
             </Link>
           </div>
+
+          {/* Mobile menu */}
+          {menuOpen && (
+            <div className="absolute top-20 left-0 w-full bg-white border-b md:hidden z-10">
+              <div className="flex flex-col p-4 space-y-2">
+                <Link href="/learn-mri" className={linkClass('/learn-mri')}
+                  onClick={() => setMenuOpen(false)}>
+                  Learn MRI
+                </Link>
+                <Link href="/news" className={linkClass('/news')}
+                  onClick={() => setMenuOpen(false)}>
+                  News
+                </Link>
+                <Link href="/research-topic" className={linkClass('/research-topic')}
+                  onClick={() => setMenuOpen(false)}>
+                  Research
+                </Link>
+                <Link href="/podcasts" className={linkClass('/podcasts')}
+                  onClick={() => setMenuOpen(false)}>
+                  Podcasts
+                </Link>
+              </div>
+            </div>
+          )}
 
           <div className="flex items-center gap-4">
             <button className="p-2 mr-2">

--- a/components/NewsSection.tsx
+++ b/components/NewsSection.tsx
@@ -49,7 +49,7 @@ export default async function NewsSection() {
         </Link>
       </div>
 
-      <div className="grid grid-cols-4 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
         {newsData.map((item, index) => (
           <Link href={item.slug ? `/news/${item.slug.current}` : "#"} key={index} className="group">
             <div className="relative h-[360px] overflow-hidden rounded-lg">


### PR DESCRIPTION
## Summary
- add a collapsible mobile menu in the Navbar
- stack banner contents vertically on small screens
- make News grid responsive
- fix footer layout on small devices
- tweak Learn MRI landing page links
- adjust News and Podcast pages for mobile
- cleanup homepage layout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac61f30d883218a81315aa9aa8490